### PR TITLE
Replace hard-coded ticker color with Timeline's outline color

### DIFF
--- a/src/ofxTLTicker.cpp
+++ b/src/ofxTLTicker.cpp
@@ -65,7 +65,7 @@ void ofxTLTicker::draw(){
 		refreshTickMarks();
 	}
 	
-	tickerMarks.setStrokeColor( ofColor(200, 180, 40) );
+	tickerMarks.setStrokeColor(timeline->getColors().outlineColor);
 	tickerMarks.setStrokeWidth(1);
 	tickerMarks.draw(0, bounds.y);
 		
@@ -148,7 +148,7 @@ void ofxTLTicker::draw(){
 	ofDrawLine(currentFrameX, totalDrawRect.y, currentFrameX, totalDrawRect.y+totalDrawRect.height);
 	//draw bounds 
 	ofNoFill();
-	ofSetColor(200, 180, 40);
+	ofSetColor(timeline->getColors().outlineColor);
 	ofDrawRectangle(bounds);
 		
 	ofPopStyle();


### PR DESCRIPTION
The outline color in `defaultColors.xml` is slightly different from the hard-coded one (`149, 204, 103` vs `200, 180, 40`) but is perceptually similar -- it's that yellow. This PR lets you use the xml outline color to change the ticker marks & track outlines together, without changing the code.

![timeline](https://cloud.githubusercontent.com/assets/2334552/23957895/e28442ca-0976-11e7-9ec3-fd50e0912dca.png)
_look how pretty_

pinging @obviousjim because https://github.com/YCAMInterlab/ofxTimeline/blame/f6abd79698f746c9924db4d71c39bbad7b7bfbfa/src/ofxTLTicker.cpp#L35-L36